### PR TITLE
Add support for other notify services. 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Build Inventory Image'
+      - name: 'Build and Push Image'
         run: |
-          docker build . --tag ghcr.io/govuk-digital-backbone/govuk-notify-smtp-relay:latest
-          docker push ghcr.io/govuk-digital-backbone/govuk-notify-smtp-relay:latest
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/gcnotify-smtp-relay
+          VERSION=latest
+          echo "Building $IMAGE_ID:$VERSION"
+          docker build . --tag $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions: write-all
+permissions: read-all
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
@@ -26,7 +29,7 @@ jobs:
         run: |
           # Force everything to lowercase
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_ID=ghcr.io/$OWNER/gcnotify-smtp-relay
+          IMAGE_ID=ghcr.io/$OWNER/govuk-notify-smtp-relay
           VERSION=latest
           echo "Building $IMAGE_ID:$VERSION"
           docker build . --tag $IMAGE_ID:$VERSION

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: 'Build and Push Image'
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/gcnotify-smtp-relay
+          # Force everything to lowercase
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_ID=ghcr.io/$OWNER/gcnotify-smtp-relay
           VERSION=latest
           echo "Building $IMAGE_ID:$VERSION"
           docker build . --tag $IMAGE_ID:$VERSION

--- a/main.py
+++ b/main.py
@@ -14,9 +14,18 @@ SMTP_PORT = int(os.getenv("SMTP_PORT", 2525))
 NOTIFY_API_KEY = os.getenv("NOTIFY_API_KEY", None)
 NOTIFY_TEMPLATE_ID = os.getenv("NOTIFY_TEMPLATE_ID", None)
 
+NOTIFY_BASE_URL = os.getenv(
+    "NOTIFY_BASE_URL",
+    "https://api.notifications.service.gov.uk"
+)
+
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", None)
 
-notifications_client = NotificationsAPIClient(NOTIFY_API_KEY) if NOTIFY_API_KEY else None
+notifications_client = (
+    NotificationsAPIClient(NOTIFY_API_KEY, base_url=NOTIFY_BASE_URL)
+    if NOTIFY_API_KEY
+    else None
+)
 
 def is_private_ip(ip):
     if not ip:


### PR DESCRIPTION
was working on a keycloak project and keycloak only supports smtp so i need a smtp2notify bridge.

In the government of canada we have a similar service of UK Notify called [GC Notify ](https://notification.canada.ca/)

Using your code and this PR, this container can now support various Notify(like) providers

Changes:

- Updated python to accept url variable to start api service
- Updated action to be more repo agnostic and correct action permissions  

for your review @OllieJC 